### PR TITLE
Fixed images being recycled before saving

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/HookedLayouts.java
+++ b/app/src/main/java/com/marz/snapprefs/HookedLayouts.java
@@ -9,15 +9,11 @@ import android.content.Intent;
 import android.content.res.XModuleResources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.LinearGradient;
-import android.graphics.Paint;
 import android.graphics.Point;
-import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.Typeface;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.PaintDrawable;
 import android.graphics.drawable.ShapeDrawable;
@@ -214,8 +210,7 @@ public class HookedLayouts {
                 ).getParent();
 
                 ViewGroup overlay_group = (ViewGroup) liparam.view.findViewById(
-                        liparam.res.getIdentifier("my_story_swipe_layout", "id", Common.PACKAGE_SNAP)
-                );
+                        liparam.res.getIdentifier("my_story_swipe_layout", "id", Common.PACKAGE_SNAP));
 
                 saveStoryButton = new ImageButton(localContext);
                 saveStoryButton.setLayoutParams(layoutParams);

--- a/app/src/main/java/com/marz/snapprefs/Saving.java
+++ b/app/src/main/java/com/marz/snapprefs/Saving.java
@@ -595,12 +595,22 @@ public class Saving {
         }
 
         // Get the bitmap payload
-        Bitmap bmp = (Bitmap) param.args[0];
+        Bitmap originalBmp = (Bitmap) param.args[0];
 
-        if (bmp == null) {
+        if (originalBmp == null) {
             Logger.printFinalMessage("Tried to attach Null Bitmap");
             return;
         }
+
+        if( originalBmp.isRecycled() )
+        {
+            Logger.printFinalMessage("Bitmap is already recycled");
+            snapData.addFlag(FlagState.FAILED);
+            createStatefulToast("Error saving image", ToastType.BAD);
+            return;
+        }
+
+        Bitmap bmp = originalBmp.copy(Bitmap.Config.ARGB_8888, false);
 
         Logger.printMessage("Pulled Bitmap");
 

--- a/app/src/main/res/xml/sharing_prefs.xml
+++ b/app/src/main/res/xml/sharing_prefs.xml
@@ -3,6 +3,7 @@
     <ListPreference
         android:defaultValue="@string/pref_rotation_default"
         android:dialogTitle="@string/pref_rotation_title"
+        android:summary="%s"
         android:entries="@array/pref_rotation_entries"
         android:entryValues="@array/pref_rotation_values"
         android:key="pref_rotation"
@@ -11,6 +12,7 @@
     <ListPreference
         android:defaultValue="@string/pref_adjustment_default"
         android:dialogTitle="@string/pref_adjustment_title"
+        android:summary="%s"
         android:entries="@array/pref_adjustment_entries"
         android:entryValues="@array/pref_adjustment_values"
         android:key="pref_adjustment"


### PR DESCRIPTION
Currently images are being referenced, which means when the asynchronous save occurs, sometimes snapchat has already recycled them (Especially if the user spams snaps).

I've changed it to make a copy of them instead so that recycling is no longer a problem
