### PR TITLE
Re-Added android.os.Environment import to HookMethods.java

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/HookMethods.java
+++ b/app/src/main/java/com/marz/snapprefs/HookMethods.java
@@ -10,6 +10,7 @@ import android.content.res.XResources;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Environment;
 import android.text.InputFilter;
 import android.util.Log;
 import android.view.View;


### PR DESCRIPTION
Fixes missing import from #936b8d9
