### PR TITLE
Fix "unhandled filter" crash and added method to obfuscator class

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Obfuscator.java
+++ b/app/src/main/java/com/marz/snapprefs/Obfuscator.java
@@ -305,6 +305,7 @@ public class Obfuscator {
         public static final String FILTER_GETVIEW = "c";
         public static final String BRYO_SNAPTYPE = "com.snapchat.android.app.feature.messaging.chat.type.SnapType";
         public static final String VISUALFILTER_TYPE = "com.snapchat.android.app.shared.feature.preview.model.filter.VisualFilterType";
+        public static final String VISUAL_FILTER_TYPE_CHECK_METHOD = "y";
     }
     public class timer {
         public static final String TAKESNAPBUTTON_CLASS = "com.snapchat.android.ui.camera.TakeSnapButton";

--- a/app/src/main/java/com/marz/snapprefs/VisualFilters.java
+++ b/app/src/main/java/com/marz/snapprefs/VisualFilters.java
@@ -116,7 +116,7 @@ public class VisualFilters {
 
     public static void initVisualFilters(final XC_LoadPackage.LoadPackageParam lpparam){
         setPreferences();
-        XposedHelpers.findAndHookMethod(Obfuscator.visualfilters.FILTERMETRICSPROVIDER_CLASS, lpparam.classLoader, "d", XposedHelpers.findClass(Obfuscator.visualfilters.ANNOTATEDMEDIABRYO, lpparam.classLoader), new XC_MethodHook() {
+        XposedHelpers.findAndHookMethod(Obfuscator.visualfilters.FILTERMETRICSPROVIDER_CLASS, lpparam.classLoader, Obfuscator.visualfilters.VISUAL_FILTER_TYPE_CHECK_METHOD, XposedHelpers.findClass(Obfuscator.visualfilters.ANNOTATEDMEDIABRYO, lpparam.classLoader), new XC_MethodHook() {
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 if (param.hasThrowable()) {


### PR DESCRIPTION
Fixes "Visual filter isn't handled <Filter Name>" Crash
