### PR TITLE
Show display names instead of usernames on group edit screen

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Friend.java
+++ b/app/src/main/java/com/marz/snapprefs/Friend.java
@@ -11,6 +11,8 @@ public class Friend implements Serializable {
 
     private String name;
 
+    private String displayName;
+
     private boolean isSelected;
 
     public Friend() {
@@ -22,9 +24,10 @@ public class Friend implements Serializable {
         this.name = name;
     }
 
-    public Friend(String name, boolean isSelected) {
+    public Friend(String name, String disName, boolean isSelected) {
 
         this.name = name;
+        this.displayName = disName;
         this.isSelected = isSelected;
     }
 
@@ -34,6 +37,14 @@ public class Friend implements Serializable {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String disName) {
+        this.displayName = disName;
     }
 
     public boolean isSelected() {

--- a/app/src/main/java/com/marz/snapprefs/Friend.java
+++ b/app/src/main/java/com/marz/snapprefs/Friend.java
@@ -27,6 +27,9 @@ public class Friend implements Serializable {
     public Friend(String name, String disName, boolean isSelected) {
 
         this.name = name;
+        if(disName != "") {
+            Logger.log("Logging Display Name In Friend.java: " + disName, true, true);
+        }
         this.displayName = disName;
         this.isSelected = isSelected;
     }

--- a/app/src/main/java/com/marz/snapprefs/Groups.java
+++ b/app/src/main/java/com/marz/snapprefs/Groups.java
@@ -137,6 +137,7 @@ public class Groups {
         for (int i = 0; i <= friends.size() - 1; i++) {
             String username = (String) callMethod(friends.get(i), Obfuscator.groups.GETUSERNAME_METHOD);
             String displayName = (String) callMethod(friends.get(i), Obfuscator.groups.GETDISPLAYNAME_METHOD);
+            Logger.log("Logging Display Name In Groups Method: " + displayName, true, true);
             if (selectedGroup != null && selectedGroup.users.contains(username)) {
                 friendList.add(new Friend(username, displayName, true));
             } else {

--- a/app/src/main/java/com/marz/snapprefs/Groups.java
+++ b/app/src/main/java/com/marz/snapprefs/Groups.java
@@ -27,6 +27,7 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import static de.robv.android.xposed.XposedHelpers.callMethod;
 import static de.robv.android.xposed.XposedHelpers.callStaticMethod;
 import static de.robv.android.xposed.XposedHelpers.findClass;
+import static de.robv.android.xposed.XposedHelpers.getObjectField;
 import static de.robv.android.xposed.XposedHelpers.newInstance;
 
 public class Groups {
@@ -137,7 +138,6 @@ public class Groups {
         for (int i = 0; i <= friends.size() - 1; i++) {
             String username = (String) callMethod(friends.get(i), Obfuscator.groups.GETUSERNAME_METHOD);
             String displayName = (String) callMethod(friends.get(i), Obfuscator.groups.GETDISPLAYNAME_METHOD);
-            Logger.log("Logging Display Name In Groups Method: " + displayName, true, true);
             if (selectedGroup != null && selectedGroup.users.contains(username)) {
                 friendList.add(new Friend(username, displayName, true));
             } else {

--- a/app/src/main/java/com/marz/snapprefs/Groups.java
+++ b/app/src/main/java/com/marz/snapprefs/Groups.java
@@ -136,10 +136,11 @@ public class Groups {
         friendList.clear();
         for (int i = 0; i <= friends.size() - 1; i++) {
             String username = (String) callMethod(friends.get(i), Obfuscator.groups.GETUSERNAME_METHOD);
+            String displayName = (String) callMethod(friends.get(i), Obfuscator.groups.GETDISPLAYNAME_METHOD);
             if (selectedGroup != null && selectedGroup.users.contains(username)) {
-                friendList.add(new Friend(username, true));
+                friendList.add(new Friend(username, displayName, true));
             } else {
-                friendList.add(new Friend(username, false));
+                friendList.add(new Friend(username, displayName, false));
             }
         }
         Collections.sort(friendList, new Friend.friendComparator());

--- a/app/src/main/java/com/marz/snapprefs/Obfuscator.java
+++ b/app/src/main/java/com/marz/snapprefs/Obfuscator.java
@@ -412,7 +412,7 @@ public class Obfuscator implements Serializable {
         public final static String INTERFACE = "Ml";//prev. BS
         public final static String GETFRIENDMANAGER_METHOD = "h";//prev. e
         public final static String GETUSERNAME_METHOD = "d";//prev. g
-        public final static String GETDISPLAYNAME_METHOD = "g";
+        public final static String GETDISPLAYNAME_METHOD = "f";
     }
     public static class bus {
         public final static String UPDATEEVENT_CLASS = "Ds";

--- a/app/src/main/java/com/marz/snapprefs/Obfuscator.java
+++ b/app/src/main/java/com/marz/snapprefs/Obfuscator.java
@@ -412,6 +412,7 @@ public class Obfuscator implements Serializable {
         public final static String INTERFACE = "Ml";//prev. BS
         public final static String GETFRIENDMANAGER_METHOD = "h";//prev. e
         public final static String GETUSERNAME_METHOD = "d";//prev. g
+        public final static String GETDISPLAYNAME_METHOD = "g";
     }
     public static class bus {
         public final static String UPDATEEVENT_CLASS = "Ds";

--- a/app/src/main/java/com/marz/snapprefs/Obfuscator.java
+++ b/app/src/main/java/com/marz/snapprefs/Obfuscator.java
@@ -373,6 +373,7 @@ public class Obfuscator {
         public static final String INTERFACE = "Ml";//prev. BS
         public static final String GETFRIENDMANAGER_METHOD = "h";//prev. e
         public static final String GETUSERNAME_METHOD = "d";//prev. g
+        public static final String GETDISPLAYNAME_METHOD = "g";
     }
     public class bus {
         public static final String UPDATEEVENT_CLASS = "Ds";

--- a/app/src/main/java/com/marz/snapprefs/Stories.java
+++ b/app/src/main/java/com/marz/snapprefs/Stories.java
@@ -89,9 +89,9 @@ public class Stories {
         for (int i = 0; i <= friends.size() - 1; i++) {
             String username = (String) XposedHelpers.callMethod(friends.get(i), Obfuscator.save.GET_FRIEND_USERNAME);
             if (peopleToHide.contains(username)) {
-                friendList.add(new Friend(username, true));
+                friendList.add(new Friend(username, "", true));
             } else {
-                friendList.add(new Friend(username, false));
+                friendList.add(new Friend(username, "", false));
             }
         }
         Collections.sort(friendList, new Friend.friendComparator());

--- a/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
+++ b/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
@@ -60,7 +60,8 @@ public class GroupDataAdapter extends RecyclerView.Adapter<GroupDataAdapter.View
         viewHolder.tvName = (TextView) viewHolder.itemView.getChildAt(0);
         viewHolder.chkSelected = (CheckBox) viewHolder.itemView.getChildAt(1);
 
-        viewHolder.tvName.setText(friendList.get(position).getName());
+        viewHolder.tvName.setText(friendList.get(position).getDisplayName());
+        viewHolder.tvName.setHint(friendList.get(position).getName());
 
         viewHolder.chkSelected.setChecked(friendList.get(position).isSelected());
 

--- a/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
+++ b/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 
 import com.marz.snapprefs.Friend;
 import com.marz.snapprefs.GroupDialog;
+import com.marz.snapprefs.Logger;
 import com.marz.snapprefs.R;
 
 import java.util.List;
@@ -60,6 +61,7 @@ public class GroupDataAdapter extends RecyclerView.Adapter<GroupDataAdapter.View
         viewHolder.tvName = (TextView) viewHolder.itemView.getChildAt(0);
         viewHolder.chkSelected = (CheckBox) viewHolder.itemView.getChildAt(1);
 
+        Logger.log("Logging Display Name In GroupDataAdapter.java: " + friendList.get(position).getDisplayName(), true, true);
         viewHolder.tvName.setText(friendList.get(position).getDisplayName());
         viewHolder.tvName.setHint(friendList.get(position).getName());
 

--- a/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
+++ b/app/src/main/java/com/marz/snapprefs/Util/GroupDataAdapter.java
@@ -61,7 +61,6 @@ public class GroupDataAdapter extends RecyclerView.Adapter<GroupDataAdapter.View
         viewHolder.tvName = (TextView) viewHolder.itemView.getChildAt(0);
         viewHolder.chkSelected = (CheckBox) viewHolder.itemView.getChildAt(1);
 
-        Logger.log("Logging Display Name In GroupDataAdapter.java: " + friendList.get(position).getDisplayName(), true, true);
         viewHolder.tvName.setText(friendList.get(position).getDisplayName());
         viewHolder.tvName.setHint(friendList.get(position).getName());
 


### PR DESCRIPTION
Friends username can be retrieve via the textView.getHint(), but while looking into it it appears that SP doesn't care what the text field is because it pulls straight from the friend object
