### PR TITLE
Added obfuscation to the usernames when logged in the story blocking

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Stories.java
+++ b/app/src/main/java/com/marz/snapprefs/Stories.java
@@ -12,6 +12,7 @@ import android.widget.RelativeLayout;
 
 import com.marz.snapprefs.Preferences.Prefs;
 import com.marz.snapprefs.Util.FileUtils;
+import com.marz.snapprefs.Util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -172,7 +173,7 @@ public class Stories {
                     String friendUsername = (String) callMethod(obj, Obfuscator.stories.RECENTSTORY_GETUSERNAME);
 
                     if (friendUsername != null && peopleToHide.contains(friendUsername)) {
-                        Logger.log("Contains blocked friend.... Removing " + friendUsername);
+                        Logger.log("Contains blocked friend.... Removing " + StringUtils.obfus(friendUsername));
                         objectList.remove(obj);
                     }
                 }
@@ -185,7 +186,7 @@ public class Stories {
                     String friendUsername = (String) callMethod(obj, Obfuscator.stories.RECENTSTORY_GETUSERNAME);
 
                     if (friendUsername != null && peopleToHide.contains(friendUsername)) {
-                        Logger.log("Contains blocked friend.... Removing " + friendUsername);
+                        Logger.log("Contains blocked friend.... Removing " + StringUtils.obfus(friendUsername));
                         objectList.remove(obj);
                     }
                 }


### PR DESCRIPTION
Obfuscated the usernames when logged in the blocked stories

## Motivation and Context
Saw un-obfuscated usernames in an uploaded log in this section.

## How Has This Been Tested?
No Testing, simple string alteration change using an already tested util.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added every class/field/method name to the Obfuscator class.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

