### PR TITLE
[IMPORTANT] Fixed lenses not loading in Snapchat

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Databases/LensDatabaseHelper.java
+++ b/app/src/main/java/com/marz/snapprefs/Databases/LensDatabaseHelper.java
@@ -34,7 +34,8 @@ public class LensDatabaseHelper extends CachedDatabaseHandler {
             LensEntry.COLUMN_NAME_MLENSLINK,
             LensEntry.COLUMN_NAME_MSIGNATURE,
             LensEntry.COLUMN_NAME_ACTIVE,
-            LensEntry.COLUMN_NAME_SEL_TIME
+            LensEntry.COLUMN_NAME_SEL_TIME,
+            LensEntry.COLUMN_NAME_LENS_NAME
     };
     private static final String TEXT_TYPE = " TEXT";
     private static final String INT_TYPE = " INTEGER";


### PR DESCRIPTION
Resolves issues #355 

Issue was simply due to the database projection not being updated to reflect the Lens Naming update. 

<b>LENS COLLECTION WAS NOT AFFECTED, ONLY LENS LOADING</b>.  You have not missed out on any lenses. 