### PR TITLE
Change Default Debug settings based on build type

### DIFF
--- a/app/src/main/java/com/marz/snapprefs/Preferences.java
+++ b/app/src/main/java/com/marz/snapprefs/Preferences.java
@@ -400,7 +400,7 @@ public class Preferences {
         SAVE_SENT_SNAPS("pref_key_save_sent_snaps", true),
         SORT_BY_CATEGORY("pref_key_sort_files_mode", false),
         SORT_BY_USERNAME("pref_key_sort_files_username", true),
-        DEBUGGING("pref_key_debug", true),
+        DEBUGGING("pref_key_debug", BuildConfig.BUILD_TYPE.toLowerCase() == "debug"),
         OVERLAYS("pref_key_overlay", false),
         SPEED("pref_key_speed", false),
         WEATHER("pref_key_weather", false),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set default debug setting to the result of BuildConfig.BUILD_TYPE.toLowerCase() == "debug"
## Motivation and Context
Logging can cause significant lag, and SHOULD NOT be enabled by default in release builds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added every class/field/method name to the Obfuscator class.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
